### PR TITLE
Fix typos found by codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ You can also debug the server using the [MCP Inspector](https://github.com/model
 # Run in UI mode with stdio transport (can switch to HTTP/SSE in the Web UI as needed)
 npx @modelcontextprotocol/inspector uv run modelscope-mcp-server
 
-# Run in CLI mode with HTTP transportt (can do operations across tools, resources, and prompts)
+# Run in CLI mode with HTTP transport (can do operations across tools, resources, and prompts)
 npx @modelcontextprotocol/inspector --cli http://127.0.0.1:8000/mcp/ --transport http --method tools/list
 ```
 

--- a/src/modelscope_mcp_server/tools/aigc.py
+++ b/src/modelscope_mcp_server/tools/aigc.py
@@ -41,7 +41,7 @@ def register_aigc_tools(mcp: FastMCP) -> None:
         model: Annotated[
             str | None,
             Field(
-                description="The model's ID fo be used for image generation. "
+                description="The model's ID to be used for image generation. "
                 "If not provided, uses the default model provided in server settings."
             ),
         ] = None,


### PR DESCRIPTION
## Summary
- fix a typo in README
- fix typo in AIGC tool description

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b1b979d34832bbe4f333b21f366ab